### PR TITLE
feat: '기여자' 탭 번역 추가

### DIFF
--- a/chrome/github-ko.ts
+++ b/chrome/github-ko.ts
@@ -305,6 +305,7 @@ const 번역목록: 번역정보[] = [
     번역("1300D", ".d-flex.flex-items-start a", [[/New/, "새 저장소"]]),
     번역("1300E", ".BtnGroup button", [[/Previous/, "이전"], [/Next/, "다음"]]), //Previous와 Next가 버튼과 링크로 서로 전환될 때를 대비
     번역("1300E", ".BtnGroup a", [[/Previous/, "이전"], [/Next/, "다음"]]),
+    번역("1300F", "#repo-content-pjax-container > div > div.Layout.Layout--flowRow-until-md.Layout--sidebarPosition-end.Layout--sidebarPosition-flowRow-end > div.Layout-sidebar > div > div > div > h2 > a", [[/Contributors/, "기여자"]]),
 
 ];
 


### PR DESCRIPTION
## 요약:

우측 사이드바에 표시되는 `Contributors`탭이 `기여자`로 보이도록 새 번역을 추가했습니다.

## 자세한 변경내용:

* 새로 추가한 룰 인덱스: `1300F`
* 사용한 선택자:
```css
#repo-content-pjax-container > div > div.Layout.Layout--flowRow-until-md.Layout--sidebarPosition-end.Layout--sidebarPosition-flowRow-end > div.Layout-sidebar > div > div > div > h2 > a
```
* 번역 패턴:
```ts
[[/Contributors/, "기여자"]]
```

## 테스트:

다음 브라우저들에서 테스트되었습니다.

* Google Chrome (97.0.4692.99)
* Chromium (97.0.4692.99)